### PR TITLE
fix emit ack callback pass to server and call back

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,10 @@ export default class SocketMock extends Emitter {
    * Emit an event to the server (used by client)
    * @param  {string} eventKey -- The event key
    * @param  {object} payload -- Additional payload
+   * @param  {function} ack -- The ack argument is optional. When server call it payload reply will be delivered to client
   **/
-  emitEvent (eventKey, payload) {
-    this._emitFn(eventKey, createPayload(payload))
+  emitEvent (eventKey, payload, ack) {
+    this._emitFn(eventKey, createPayload(payload), ack)
   }
 
   /**

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -17,15 +17,14 @@ export default class SocketClient extends Emitter {
    * Emit an event to the server client
    * @param  {string}   eventKey -- The event key that needs to be attached
    * @param  {object}   payload  -- The payload that needs to be attached to the emit
-   * @param  {function} in_callback
+   * @param  {function} ack -- The ack argument is optional and will be called with the server answer.
    */
-  emit (eventKey, payload, cb) {
+  emit (eventKey, payload, ack) {
     if (typeof payload === 'function') {
       payload = null
-      cb = payload
+      ack = payload
     }
-    const callback = cb || function () {}
-    callback(this._socketMock.emitEvent(eventKey, payload))
+    this._socketMock.emitEvent(eventKey, payload, ack)
   }
 
   /**

--- a/test/test-socket.js
+++ b/test/test-socket.js
@@ -29,6 +29,19 @@ describe('Utils: Socket', () => {
     socket.socketClient.emit('test', eventPayload)
   })
 
+  it('should call ack on the server side when on() is assigned ack callback must be called', done => {
+    const ackPayload = { foo: 'bar' }
+    socket.on('test', (payload, ack) => {
+      ack(ackPayload)
+    })
+
+    socket.socketClient.emit('test', {}, (payload) => {
+      payload.should.have.property('foo')
+      payload.foo.should.be.equal(ackPayload.foo)
+      done()
+    })
+  })
+
   it('should fire event on the client side when on() is assigned', done => {
     socket.socketClient.on('test', payload => {
       payload.should.have.property('never')


### PR DESCRIPTION
ack callback should be callable from server, this PR fix it.

https://socket.io/docs/client-api/#socket-emit-eventName-%E2%80%A6args-ack