### PR TITLE
Allow variable number of arguments in emit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,8 @@ export default class SocketMock extends Emitter {
    * @param  {object} payload -- Additional payload
    * @param  {function} ack -- The ack argument is optional. When server call it payload reply will be delivered to client
   **/
-  emitEvent (eventKey, payload, ack) {
-    this._emitFn(eventKey, createPayload(payload), ack)
+  emitEvent (eventKey, args, ack) {
+    this._emitFn(eventKey, ...args.map(createPayload), ack)
   }
 
   /**

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -19,12 +19,12 @@ export default class SocketClient extends Emitter {
    * @param  {object}   payload  -- The payload that needs to be attached to the emit
    * @param  {function} ack -- The ack argument is optional and will be called with the server answer.
    */
-  emit (eventKey, payload, ack) {
-    if (typeof payload === 'function') {
-      payload = null
-      ack = payload
+  emit (eventKey, ...args) {
+    let ack
+    if (typeof args[args.length - 1] === 'function') {
+      ack = args.pop()
     }
-    this._socketMock.emitEvent(eventKey, payload, ack)
+    this._socketMock.emitEvent(eventKey, args, ack)
   }
 
   /**

--- a/test/test-socket.js
+++ b/test/test-socket.js
@@ -29,6 +29,18 @@ describe('Utils: Socket', () => {
     socket.socketClient.emit('test', eventPayload)
   })
 
+  it('should fire event on the server side when on() is assigned and multiple parameters are passed', done => {
+    socket.on('test', (arg1, arg2, arg3) => {
+      arg1.should.be.equal(1)
+      arg2.should.be.equal(2)
+      arg3.should.be.equal(3)
+
+      done()
+    })
+
+    socket.socketClient.emit('test', 1, 2, 3)
+  })
+
   it('should call ack on the server side when on() is assigned ack callback must be called', done => {
     const ackPayload = { foo: 'bar' }
     socket.on('test', (payload, ack) => {
@@ -38,6 +50,16 @@ describe('Utils: Socket', () => {
     socket.socketClient.emit('test', {}, (payload) => {
       payload.should.have.property('foo')
       payload.foo.should.be.equal(ackPayload.foo)
+      done()
+    })
+  })
+
+  it('should call ack on the server side when on() is assigned and no payload was passed', done => {
+    socket.on('test', ack => {
+      ack()
+    })
+
+    socket.socketClient.emit('test', () => {
       done()
     })
   })


### PR DESCRIPTION
Closes #16. The proposed solution in that issue has the ack as the second arg instead of the last. This order matches the socket.io api.